### PR TITLE
Update export-in-progress.ts DOM text reinterpreted as HTML

### DIFF
--- a/server-static-src/export-in-progress.ts
+++ b/server-static-src/export-in-progress.ts
@@ -122,7 +122,7 @@ function updateTable(data: ITableExport) {
   const fileType = driveFile ? driveFile.mimeType : undefined;
 
   if (data.error) {
-    $listEntry.innerHTML += `
+    $listEntry.innerText += `
       <div class="fusiontable__error">
         <div class="fusiontable__error__message">
           ${data.error}


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.