### PR TITLE
Update-2 export-in-progress.ts DOM text reinterpreted as HTML

### DIFF
--- a/server-static-src/export-in-progress.ts
+++ b/server-static-src/export-in-progress.ts
@@ -251,5 +251,5 @@ function renderVisualizationLink(
     </a>
   `;
 
-  $visualization.innerHTML += markup;
+  $visualization.innerText += markup;
 }


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.